### PR TITLE
Api gateway fix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,9 +36,18 @@ export const update = async (): Promise<void> => {
 };
 
 export const createPR = async (): Promise<void> => {
-    db.createPR();
-    setInterval(() => {
+    try {
         db.createPR();
+    } catch (err) {
+        debug('Error adding new PR:' + err);
+    }
+
+    setInterval(() => {
+        try {
+            db.createPR();
+        } catch (err) {
+            debug('Error adding new PR:' + err);
+        }
     }, config.autoPR.interval);
 };
 

--- a/src/utils/apiKeyTest.ts
+++ b/src/utils/apiKeyTest.ts
@@ -5,15 +5,17 @@ export const isValidApiKey = (input: string): boolean => {
     return true;
 };
 
-export const apiKeyOwner = async (input: string, inputid: string, apiKey: string): Promise<any> => {
+export const apiKeyOwner = async (input: string, inputid: string): Promise<any> => {
     return new Promise((resolve, reject) => {
         const options = {
             uri: 'https://9441laq953.execute-api.us-east-1.amazonaws.com/prod/getapiname/',
             headers: {
-                'x-api-key': apiKey,
+                'x-api-key': input,
                 data: inputid
             }
         };
+        console.log('Making req with: ');
+        console.log(JSON.stringify(options, null, 2));
         request(options, (err, result, body) => {
             console.log(body);
             if (err) {

--- a/src/utils/apiKeyTest.ts
+++ b/src/utils/apiKeyTest.ts
@@ -1,24 +1,31 @@
+import * as request from 'request';
+
 export const isValidApiKey = (input: string): boolean => {
     // TODO: replace this logic to allow multi-key functionality.
-    if (input === 'TestApiKey') {
-        return true;
-    } else {
-        return false;
-    }
+    return true;
 };
 
-export const apiKeyOwner = (input: string): string => {
-    const apiKeys = {
-        TestApiKey: {
-            key: 'TestApiKey',
-            name: 'Tester'
-        }
-    };
-
-    if (isValidApiKey(input)) {
-        const index = apiKeys[input];
-        return index.name;
-    } else {
-        return 'Invalid Api Key';
-    }
+export const apiKeyOwner = async (input: string, inputid: string, apiKey: string): Promise<any> => {
+    return new Promise((resolve, reject) => {
+        const options = {
+            uri: 'https://9441laq953.execute-api.us-east-1.amazonaws.com/prod/getapiname/',
+            headers: {
+                'x-api-key': apiKey,
+                data: inputid
+            }
+        };
+        request(options, (err, result, body) => {
+            console.log(body);
+            if (err) {
+                console.log(err);
+                resolve(undefined);
+            } else {
+                if (JSON.parse(body).body.success) {
+                    resolve(JSON.parse(body).body.name);
+                } else {
+                    resolve('unknown');
+                }
+            }
+        });
+    });
 };

--- a/src/utils/apiKeyTest.ts
+++ b/src/utils/apiKeyTest.ts
@@ -5,21 +5,18 @@ export const isValidApiKey = (input: string): boolean => {
     return true;
 };
 
-export const apiKeyOwner = async (input: string, inputid: string): Promise<any> => {
+export const apiKeyOwner = async (input: string): Promise<any> => {
     return new Promise((resolve, reject) => {
         const options = {
             uri: 'https://9441laq953.execute-api.us-east-1.amazonaws.com/prod/getapiname/',
             headers: {
                 'x-api-key': input,
-                data: inputid
+                data: input
             }
         };
-        console.log('Making req with: ');
-        console.log(JSON.stringify(options, null, 2));
+
         request(options, (err, result, body) => {
-            console.log(body);
             if (err) {
-                console.log(err);
                 resolve(undefined);
             } else {
                 if (JSON.parse(body).body.success) {

--- a/src/utils/autoPR.ts
+++ b/src/utils/autoPR.ts
@@ -18,7 +18,7 @@ export const autoPR = async (input: any, githubKey: string): Promise<any> => {
                 safeDump(input, { lineWidth: 99999999, indent: 4 })
             );
         } catch (e) {
-            reject(e);
+            resolve(e);
         }
         try {
             /* Try to pr */

--- a/src/utils/autoPR.ts
+++ b/src/utils/autoPR.ts
@@ -39,7 +39,7 @@ export const autoPR = async (input: any, githubKey: string): Promise<any> => {
             }
         } catch (e) {
             await fork.delete();
-            reject(e);
+            resolve(e);
         }
     });
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,6 +21,7 @@ export interface Config {
         VirusTotal: string;
         Google_Captcha: string;
         Slack_Webhook: string;
+        AWS: string;
     };
     autoPull: {
         enabled: boolean;
@@ -76,7 +77,8 @@ if (!fs.existsSync('./config.json')) {
             Github_AccessKey: undefined,
             VirusTotal: undefined,
             Google_Captcha: undefined,
-            Slack_Webhook: undefined
+            Slack_Webhook: undefined,
+            AWS: undefined
         },
         autoPull: { enabled: false },
         autoPR: {

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -192,34 +192,36 @@ export const createPR = async (): Promise<void> => {
         // Do nothing; empty reported cache
     } else {
         debug(db.reported.length + ' entries found in report cache.');
+        debug(JSON.stringify(db.reported, null, 2));
         db.reported.forEach(async entry => {
             try {
+                debug('Trying to remove entry from report cache');
                 const successStatus = await autoPR.autoPR(entry, config.apiKeys.Github_AccessKey);
                 if (successStatus.success) {
                     if (successStatus.url) {
                         // Success
-                        debug('Removing entry from report list');
+                        debug('Removing entry from report cache');
                         db.reported = db.reported.filter(el => {
                             return el !== entry;
                         });
                         exitHandler();
-                        debug('Url entry ' + successStatus.url + ' removed from the cache.');
+                        debug('Url entry removed from report cache.');
                     } else {
                         // Success
-                        debug('Removing entry from report list.');
+                        debug('Removing entry from report cache.');
                         db.reported = db.reported.filter(el => {
                             return el !== entry;
                         });
                         exitHandler();
-                        debug('Entry removed from the cache.');
+                        debug('Entry removed from report cache.');
                     }
                 } else {
                     // Failure
-                    debug('Entry could not be removed from the cache.');
+                    debug('Entry could not be removed from report cache.');
                 }
             } catch (e) {
                 // Failure
-                debug('Github server err in removing entry: ' + e);
+                debug('Github server err in removing entry from report cache: ' + e);
             }
         });
     }
@@ -242,6 +244,12 @@ export const addReport = async (entry: EntryWrapper) => {
 
 export const checkReport = async (entry: EntryWrapper): Promise<boolean> => {
     if (db.reported.find(el => el !== entry)) {
+        debug(
+            'Entry: ' +
+                JSON.stringify(el, null, 2) +
+                ' matches input entry: ' +
+                JSON.stringify(entry, null, 2)
+        );
         return true;
     } else {
         return false;

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -119,12 +119,12 @@ export const updateIndex = async (): Promise<void> => {
         .sort((a, b) => a.name.localeCompare(b.name));
     db.index.blacklist = [
         ...db.scams
-            .filter(entry => entry.path == '/*')
+            .filter(entry => entry.path === '/*')
             .map(entry => entry.getHostname().replace('www.', '')),
         ...db.scams
-            .filter(entry => entry.path == '/*')
+            .filter(entry => entry.path === '/*')
             .map(entry => entry.getHostname().replace('www.', '')),
-        ...Object.keys(scamDictionary.ip || {}).filter(ip => scamDictionary.ip[ip].path == '/*')
+        ...Object.keys(scamDictionary.ip || {}).filter(ip => scamDictionary.ip[ip].path === '/*')
     ];
     db.index.whitelist = [
         ...db.verified.map(entry => url.parse(entry.url).hostname.replace('www.', '')),
@@ -175,6 +175,7 @@ export const persist = async (): Promise<void> => {
 
 export const priceUpdate = async (): Promise<void> => {
     debug('Updating price...');
+    db.prices.cryptos = [];
     config.coins.forEach(async each => {
         const ret = await priceLookup(each.priceSource, each.priceEndpoint);
         const priceUSD = await JSON.parse(JSON.stringify(ret)).USD;

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -243,12 +243,12 @@ export const addReport = async (entry: EntryWrapper) => {
 };
 
 export const checkReport = async (entry: EntryWrapper): Promise<boolean> => {
-    if (db.reported.find(el => el !== entry)) {
+    if (db.reported.findIndex(el => el === entry) >= 0) {
         debug(
-            'Entry: ' +
-                JSON.stringify(el, null, 2) +
-                ' matches input entry: ' +
-                JSON.stringify(entry, null, 2)
+            'Input entry ' +
+                JSON.stringify(entry, null, 2) +
+                ' matches ' +
+                JSON.stringify(db.reported[db.reported.findIndex(el => el === entry)], null, 2)
         );
         return true;
     } else {

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -200,7 +200,6 @@ export const createPR = async (): Promise<void> => {
                 if (successStatus.success) {
                     if (successStatus.url) {
                         // Success
-                        debug('Removing entry from report cache');
                         db.reported = db.reported.filter(el => {
                             return el !== entry;
                         });
@@ -208,7 +207,6 @@ export const createPR = async (): Promise<void> => {
                         debug('Url entry removed from report cache.');
                     } else {
                         // Success
-                        debug('Removing entry from report cache.');
                         db.reported = db.reported.filter(el => {
                             return el !== entry;
                         });

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -192,7 +192,6 @@ export const createPR = async (): Promise<void> => {
         // Do nothing; empty reported cache
     } else {
         debug(db.reported.length + ' entries found in report cache.');
-        debug(JSON.stringify(db.reported, null, 2));
         db.reported.forEach(async entry => {
             try {
                 debug('Trying to remove entry from report cache');
@@ -241,7 +240,7 @@ export const addReport = async (entry: EntryWrapper) => {
 };
 
 export const checkReport = async (entry: EntryWrapper): Promise<boolean> => {
-    if (db.reported.findIndex(el => el === entry) >= 0) {
+    if (db.reported.find(el => el !== entry)) {
         debug(
             'Input entry ' +
                 JSON.stringify(entry, null, 2) +
@@ -250,6 +249,7 @@ export const checkReport = async (entry: EntryWrapper): Promise<boolean> => {
         );
         return true;
     } else {
+        debug('Input entry not found in reported');
         return false;
     }
 };

--- a/src/utils/lookup.ts
+++ b/src/utils/lookup.ts
@@ -120,7 +120,7 @@ const limiter = new Bottleneck({
 /* Do a URL lookup */
 export const lookup = limiter.wrap(url => {
     return new Promise<request.Response | undefined>(resolve => {
-        debug('Requesting ' + url + '...');
+        //debug('Requesting ' + url + '...');
         request(
             {
                 url,

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -56,7 +56,7 @@ router.get('/v1/featured', (req, res) =>
 );
 router.get('/v1/scams', (req, res) => res.json({ success: true, result: db.read().scams }));
 router.get('/v1/entry/:id', async (req, res) => {
-    const entry = db.read().scams.find(entry => entry.id == req.params.id);
+    const entry = db.read().scams.find(ent => ent.id === req.params.id);
     if (!entry) {
         res.json({ success: false, message: "Couldn't find requested ID" });
     } else {
@@ -77,10 +77,10 @@ router.get('/v1/entry/:id', async (req, res) => {
     }
 });
 router.get('/v1/domain/:domain', async (req, res) => {
-    const badEntries = db.read().scams.filter(entry => entry.hostname == req.params.domain);
+    const badEntries = db.read().scams.filter(entry => entry.hostname === req.params.domain);
     const goodEntries = db
         .read()
-        .verified.filter(entry => url.parse(entry.url).hostname == req.params.domain);
+        .verified.filter(entry => url.parse(entry.url).hostname === req.params.domain);
     res.json({
         success: badEntries.length > 0 || goodEntries.length > 0,
         result: [
@@ -479,15 +479,15 @@ router.get('/v1/check/:search', async (req, res) => {
                 .read()
                 .verified.find(
                     entry =>
-                        (url.parse(req.params.search).hostname || req.params.search) ===
-                        url.parse(entry.url).hostname
+                        (url.parse(req.params.search.toLowerCase()).hostname ||
+                            req.params.search.toLowerCase()) === url.parse(entry.url).hostname
                 );
             const blacklistURL = db
                 .read()
                 .scams.find(
                     entry =>
-                        (url.parse(req.params.search).hostname || req.params.search) ===
-                        entry.getHostname()
+                        (url.parse(req.params.search.toLowerCase()).hostname ||
+                            req.params.search.toLowerCase()) === entry.getHostname()
                 );
             if (whitelistURL) {
                 res.json({

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -646,8 +646,8 @@ router.get('/*', (req, res) =>
 router.put('/v1/report', async (req, res) => {
     /* API-based reporting */
     debug('req headers: ' + JSON.stringify(req.headers));
-    if (req.context) {
-        debug('req: ' + JSON.stringify(req.context));
+    if (req) {
+        debug('req: ' + JSON.stringify(req));
     }
     if (req.headers['x-api-key']) {
         const reportKey: string = req.headers['x-api-key'].toString();

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -643,6 +643,12 @@ router.put('/v1/report', async (req, res) => {
     /* API-based reporting */
     if (req.headers['x-api-key']) {
         const reportKey: string = req.headers['x-api-key'].toString();
+        debug(
+            'Incoming report: ' +
+                JSON.stringify(req.body, null, 2) +
+                ' from apikey ' +
+                req.headers['x-api-key']
+        );
         if (config.apiKeys.Github_AccessKey && config.autoPR.enabled) {
             if (reportKey) {
                 const newEntry = req.body;
@@ -731,11 +737,7 @@ router.put('/v1/report', async (req, res) => {
                         }
 
                         /* Determine reporter */
-                        const reporterLookup = await apiKeyOwner(
-                            reportKey,
-                            reportKeyID,
-                            config.apiKeys.AWS
-                        );
+                        const reporterLookup = await apiKeyOwner(reportKey, reportKeyID);
                         if (reporterLookup) {
                             newEntry.reporter = reporterLookup;
                         } else {

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -646,8 +646,8 @@ router.get('/*', (req, res) =>
 router.put('/v1/report', async (req, res) => {
     /* API-based reporting */
     debug('req headers: ' + JSON.stringify(req.headers));
-    if (req) {
-        debug('req: ' + JSON.stringify(req));
+    if (req.body) {
+        debug('req.body: ' + JSON.stringify(req.body));
     }
     if (req.headers['x-api-key']) {
         const reportKey: string = req.headers['x-api-key'].toString();

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -737,7 +737,7 @@ router.put('/v1/report', async (req, res) => {
                         }
 
                         /* Determine reporter */
-                        const reporterLookup = await apiKeyOwner(reportKey, reportKeyID);
+                        const reporterLookup = await apiKeyOwner(reportKey);
                         if (reporterLookup) {
                             newEntry.reporter = reporterLookup;
                         } else {

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -643,13 +643,17 @@ router.get('/*', (req, res) =>
     })
 );
 
-/* Incoming user reports */
-router.post('/v1/report', async (req, res) => {
+router.put('/v1/report', async (req, res) => {
     /* API-based reporting */
-    if (req.query && req.body) {
+    debug('req headers: ' + JSON.stringify(req.headers));
+    if (req.context) {
+        debug('req: ' + JSON.stringify(req.context));
+    }
+    if (req.headers['x-api-key']) {
+        const reportKey: string = req.headers['x-api-key'].toString();
         if (config.apiKeys.Github_AccessKey && config.autoPR.enabled) {
-            debug(req.query.apikey);
-            if (isValidApiKey(req.query.apikey)) {
+            debug(reportKey + '- typeof: ' + typeof reportKey);
+            if (isValidApiKey(reportKey)) {
                 const newEntry = req.body;
                 if (newEntry.addresses || newEntry.name || newEntry.url) {
                     /* Force name/url fields to standard */
@@ -727,7 +731,7 @@ router.post('/v1/report', async (req, res) => {
                         }
 
                         /* Determine reporter */
-                        const reporter = apiKeyOwner(req.query.apikey);
+                        const reporter = apiKeyOwner(reportKey);
                         newEntry.reporter = reporter;
                         const command = {
                             type: 'ADD',
@@ -785,32 +789,26 @@ router.post('/v1/report', async (req, res) => {
             });
         }
     } else {
-        /* Webapp/App-based Reporting */
-        if (
-            config.apiKeys.Google_Captcha &&
-            config.apiKeys.Slack_Webhook &&
-            req.body &&
-            req.body.args &&
-            req.body.args.captcha
-        ) {
-            const isValidCaptcha = await captcha.verifyResponse(req.body.args.captcha);
-            if (isValidCaptcha) {
-                slack.sendReport(req.body);
-                res.json({
-                    success: true
-                });
-            } else {
-                res.json({
-                    success: false,
-                    message: 'Invalid captcha response provided'
-                });
-            }
-        } else if (
-            config.apiKeys.Slack_Webhook &&
-            req.body &&
-            req.body.args &&
-            req.body.args.captcha
-        ) {
+        res.json({
+            success: false,
+            message:
+                'API key required for this method. Please include an x-api-key field in the request header.'
+        });
+    }
+});
+
+/* Incoming user reports */
+router.post('/v1/report', async (req, res) => {
+    /* Webapp/App-based Reporting */
+    if (
+        config.apiKeys.Google_Captcha &&
+        config.apiKeys.Slack_Webhook &&
+        req.body &&
+        req.body.args &&
+        req.body.args.captcha
+    ) {
+        const isValidCaptcha = await captcha.verifyResponse(req.body.args.captcha);
+        if (isValidCaptcha) {
             slack.sendReport(req.body);
             res.json({
                 success: true
@@ -818,9 +816,19 @@ router.post('/v1/report', async (req, res) => {
         } else {
             res.json({
                 success: false,
-                message: 'No captcha response provided'
+                message: 'Invalid captcha response provided'
             });
         }
+    } else if (config.apiKeys.Slack_Webhook && req.body && req.body.args && req.body.args.captcha) {
+        slack.sendReport(req.body);
+        res.json({
+            success: true
+        });
+    } else {
+        res.json({
+            success: false,
+            message: 'No captcha response provided'
+        });
     }
 });
 

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -104,6 +104,7 @@ router.get('/v1/actives', (req, res) =>
 );
 router.get('/v1/blacklist', (req, res) => res.json(db.read().index.blacklist));
 router.get('/v1/whitelist', (req, res) => res.json(db.read().index.whitelist));
+router.get('/v1/reportedlist', (req, res) => res.json(db.read().reported));
 router.get('/v1/abusereport/:domain', (req, res) => {
     const result = db
         .read()


### PR DESCRIPTION
Split `/report` endpoint into two
`POST` and `PUT`. The `PUT` method is for api-reporting.

- [x] Get PUT `/v1/report` endpoint working for valid api keys.
- [x] Look into how errors are handled for the report process.
- [ ] Internally document how API keys are created/distributed.