### PR TITLE
Regex Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "tsc --noEmit --project tsconfig.json",
     "test:autopr": "ts-node tests/testautopr --trace-warnings",
     "test:ens": "ts-node tests/testensresolve --trace-warnings",
+    "test:regex": "ts-node tests/testregex --trace-warnings",
     "clean": "rimraf cache.db node_modules data config.json",
     "prettier:diff": "prettier --write --config ./.prettierrc --list-different \"src/**/*.ts\"",
     "tscheck": "tsc --noEmit --project tsconfig.json",

--- a/src/utils/balanceLookup.ts
+++ b/src/utils/balanceLookup.ts
@@ -9,8 +9,8 @@ export const balanceLookup = async (address: string, ticker: string): Promise<an
         const returned = flatten(
             await accountLookup(address, coin.addressLookUp, coin.addressEndpoint)
         );
-        if (returned.success === false) {
-            reject(0);
+        if (returned.success === false || returned.status === false) {
+            resolve({ balance: -1 });
         } else {
             const end = 'body.' + coin.addressEndpoint;
             const ethBalance = returned[end];

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -5,6 +5,7 @@ interface ConfigCoin {
     addressLookUp: string;
     addressEndpoint: string;
     decimal: number;
+    regex: string;
 }
 
 export default [
@@ -15,15 +16,18 @@ export default [
         addressLookUp:
             'https://api.etherscan.io/api?module=account&action=balance&tag=latest&address=',
         addressEndpoint: 'result',
-        decimal: 18
+        decimal: 18,
+        regex: '^0x?[0-9A-Fa-f]{40,42}$'
     },
     {
         ticker: 'ETC',
         priceSource: 'https://min-api.cryptocompare.com/data/price?fsym=ETC&tsyms=USD',
         priceEndpoint: 'USD',
-        addressLookUp: 'https://api.nanopool.org/v1/etc/balance/',
-        addressEndpoint: 'data',
-        decimal: 18
+        addressLookUp:
+            'https://blockscout.com/etc/mainnet/api?module=account&action=balance&address=',
+        addressEndpoint: 'result',
+        decimal: 18,
+        regex: '^0x?[0-9A-Fa-f]{40,42}$'
     },
     {
         ticker: 'BTC',
@@ -31,7 +35,8 @@ export default [
         priceEndpoint: 'USD',
         addressLookUp: 'https://api.blockcypher.com/v1/btc/main/addrs/',
         addressEndpoint: 'balance',
-        decimal: 8
+        decimal: 8,
+        regex: '^([13][a-km-zA-HJ-NP-Z1-9]{25,34})'
     },
     {
         ticker: 'BCH',
@@ -39,7 +44,9 @@ export default [
         priceEndpoint: 'USD',
         addressLookUp: 'https://bch-chain.api.btc.com/v3/address/',
         addressEndpoint: 'data.balance',
-        decimal: 8
+        decimal: 8,
+        regex:
+            '^([13][a-km-zA-HJ-NP-Z1-9]{25,34})|^((bitcoincash:)?(q|p)[a-z0-9]{41})|^((BITCOINCASH:)?(Q|P)[A-Z0-9]{41})$'
     },
     {
         ticker: 'LTC',
@@ -47,6 +54,7 @@ export default [
         priceEndpoint: 'USD',
         addressLookUp: 'https://api.blockcypher.com/v1/ltc/main/addrs/',
         addressEndpoint: 'balance',
-        decimal: 8
+        decimal: 8,
+        regex: '^[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}$'
     }
 ];

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -16,6 +16,7 @@ import { categorizeUrl } from './categorize';
 import * as ensResolve from './ensResolve';
 import { balanceLookup } from './balanceLookup';
 import coins from './endpoints';
+import { testCoinType } from './testCoinType';
 
 const debug = Debug('router');
 const router = express.Router();
@@ -131,141 +132,59 @@ router.get('/v1/check/:search', async (req, res) => {
         const address = req.params.search;
         if (coins.includes(coin)) {
             const retJson = await addressCheck(address, coin);
-            res.json({ success: true, input: address, coin: coin, result: retJson });
+            res.json({ success: true, input: address, coin, result: retJson });
         } else {
             res.json({
                 success: false,
                 input: address,
                 message: 'We do not support the queried coin yet.',
-                coin: coin
+                coin
             });
         }
     } else {
-        /* Query was not specified */
-        if (/^0x?[0-9A-Fa-f]{40,42}$/.test(req.params.search)) {
-            /* Searched for an ETH/ETC address */
-            const ethAccountBalance = await (() => {
-                return new Promise(async (resolve, reject) => {
-                    coins.forEach(async each => {
-                        if (each.ticker === 'ETH') {
-                            const returned = flatten(
-                                await accountLookup(
-                                    req.params.search,
-                                    each.addressLookUp,
-                                    each.addressEndpoint
-                                )
-                            );
-                            if (returned.success === false) {
-                                reject(0);
+        try {
+            const blank = await testCoinType(req.params.search);
+            debug('blank: ' + JSON.stringify(blank, null, 4));
+            const retJson = await addressCheck(req.params.search, blank.ticker);
+            res.json({
+                success: true,
+                input: req.params.search,
+                coin: blank.ticker,
+                result: retJson
+            });
+        } catch (e) {
+            if (/((?:.eth)|(?:.luxe)|(?:.test))$/.test(req.params.search)) {
+                /* Searched for an ENS name */
+                if (
+                    /(?=([(a-z0-9A-Z)]{7,100})(?=(.eth|.luxe|.test|.xyz)$))/.test(req.params.search)
+                ) {
+                    try {
+                        const address = await ensResolve.resolve(req.params.search);
+                        if (address === '0x0000000000000000000000000000000000000000') {
+                            // If lookup failed, try again one more time, then return err;
+                            const secondaddress = await ensResolve.resolve(req.params.search);
+                            if (secondaddress === '0x0000000000000000000000000000000000000000') {
+                                debug('Issue resolving ENS name: ' + req.params.search);
+                                res.json({
+                                    success: false,
+                                    input: req.params.search,
+                                    message: 'Failed to resolve ENS name due to network errors.'
+                                });
                             } else {
-                                const end = 'body.' + each.addressEndpoint;
-                                const ethBalance = returned[end];
-                                if (ethBalance === undefined) {
-                                    resolve(-1);
-                                } else {
-                                    resolve(ethBalance);
-                                }
+                                const retJson = await addressCheck(secondaddress, 'ETH');
+                                retJson.address = secondaddress;
+                                retJson.address = address;
+                                res.json({
+                                    success: true,
+                                    input: req.params.search,
+                                    coin: 'ETH',
+                                    type: 'ENS',
+                                    validRoot: true,
+                                    result: retJson
+                                });
                             }
-                        }
-                    });
-                });
-            })();
-
-            const etcAccountBalance = await (() => {
-                return new Promise(async (resolve, reject) => {
-                    coins.forEach(async each => {
-                        if (each.ticker === 'ETC') {
-                            const returned = flatten(
-                                await accountLookup(
-                                    req.params.search,
-                                    each.addressLookUp,
-                                    each.addressEndpoint
-                                )
-                            );
-                            if (returned.success === false) {
-                                reject(0);
-                            } else {
-                                const end = 'body.' + each.addressEndpoint;
-                                const etcBalance = returned[end];
-                                if (etcBalance === undefined) {
-                                    resolve(-1);
-                                } else {
-                                    resolve(etcBalance);
-                                }
-                            }
-                        }
-                    });
-                });
-            })();
-            debug(ethAccountBalance + ' - ' + etcAccountBalance);
-            if (ethAccountBalance === -1 || etcAccountBalance === -1) {
-                if (ethAccountBalance === -1) {
-                    const retJson = await addressCheck(req.params.search, 'ETC');
-                    res.json({
-                        success: true,
-                        input: req.params.search,
-                        coin: 'ETC',
-                        message: 'Unable to find account balance for ETH. Using ETC instead.',
-                        result: retJson
-                    });
-                } else if (etcAccountBalance === -1) {
-                    const retJson = await addressCheck(req.params.search, 'ETH');
-                    res.json({
-                        success: true,
-                        input: req.params.search,
-                        coin: 'ETH',
-                        message: 'Unable to find account balance for ETC. Using ETH instead.',
-                        result: retJson
-                    });
-                }
-            } else {
-                if (ethAccountBalance > etcAccountBalance) {
-                    /* Searched for a ETH address */
-                    const retJson = await addressCheck(req.params.search, 'ETH');
-                    res.json({
-                        success: true,
-                        input: req.params.search,
-                        coin: 'ETH',
-                        result: retJson
-                    });
-                } else if (etcAccountBalance > ethAccountBalance) {
-                    /* Searched for a ETC address */
-                    const retJson = await addressCheck(req.params.search, 'ETC');
-                    res.json({
-                        success: true,
-                        input: req.params.search,
-                        coin: 'ETC',
-                        result: retJson
-                    });
-                } else if (etcAccountBalance === 0 && ethAccountBalance === 0) {
-                    /* No balance in ETH/ETC, defaulting to ETH */
-                    const retJson = await addressCheck(req.params.search, 'ETH');
-                    res.json({
-                        success: true,
-                        input: req.params.search,
-                        coin: 'ETH',
-                        result: retJson
-                    });
-                }
-            }
-        } else if (/((?:.eth)|(?:.luxe)|(?:.test))$/.test(req.params.search)) {
-            /* Searched for an ENS name */
-            if (/(?=([(a-z0-9A-Z)]{7,100})(?=(.eth|.luxe|.test|.xyz)$))/.test(req.params.search)) {
-                try {
-                    const address = await ensResolve.resolve(req.params.search);
-                    if (address === '0x0000000000000000000000000000000000000000') {
-                        // If lookup failed, try again one more time, then return err;
-                        const secondaddress = await ensResolve.resolve(req.params.search);
-                        if (secondaddress === '0x0000000000000000000000000000000000000000') {
-                            debug('Issue resolving ENS name: ' + req.params.search);
-                            res.json({
-                                success: false,
-                                input: req.params.search,
-                                message: 'Failed to resolve ENS name due to network errors.'
-                            });
                         } else {
-                            const retJson = await addressCheck(secondaddress, 'ETH');
-                            retJson.address = secondaddress;
+                            const retJson = await addressCheck(address, 'ETH');
                             retJson.address = address;
                             res.json({
                                 success: true,
@@ -276,254 +195,113 @@ router.get('/v1/check/:search', async (req, res) => {
                                 result: retJson
                             });
                         }
-                    } else {
-                        const retJson = await addressCheck(address, 'ETH');
-                        retJson.address = address;
+                    } catch (e) {
+                        debug('Issue resolving ENS name: ' + req.params.search);
                         res.json({
-                            success: true,
+                            success: false,
                             input: req.params.search,
-                            coin: 'ETH',
-                            type: 'ENS',
-                            validRoot: true,
-                            result: retJson
-                        });
-                    }
-                } catch (e) {
-                    debug('Issue resolving ENS name: ' + req.params.search);
-                    res.json({
-                        success: false,
-                        input: req.params.search,
-                        message: e.message
-                    });
-                }
-            } else {
-                res.json({
-                    success: false,
-                    input: req.params.search,
-                    coin: 'ETH',
-                    type: 'ENS',
-                    validRoot: false,
-                    message: 'Invalid ENS name'
-                });
-            }
-        } else if (/^([13][a-km-zA-HJ-NP-Z1-9]{25,34})/.test(req.params.search)) {
-            /* Searched for an BTC/BCH address */
-            if (
-                /^((bitcoincash:)?(q|p)[a-z0-9]{41})|^((BITCOINCASH:)?(Q|P)[A-Z0-9]{41})$/.test(
-                    req.params.search
-                )
-            ) {
-                /* Searched for a BCH address */
-                const retJson = await addressCheck(req.params.search, 'BCH');
-                retJson.input = req.params.search;
-                res.json(retJson);
-            } else {
-                const btcAccountBalance = await (() => {
-                    return new Promise(async (resolve, reject) => {
-                        coins.forEach(async each => {
-                            if (each.ticker === 'BTC') {
-                                const returned = flatten(
-                                    await accountLookup(
-                                        req.params.search,
-                                        each.addressLookUp,
-                                        each.addressEndpoint
-                                    )
-                                );
-                                if (returned.success === false) {
-                                    reject(0);
-                                } else {
-                                    const end = 'body.' + each.addressEndpoint;
-                                    const btcBalance = returned[end];
-                                    if (btcBalance === undefined) {
-                                        resolve(-1);
-                                    } else {
-                                        resolve(btcBalance);
-                                    }
-                                }
-                            }
-                        });
-                    });
-                })();
-
-                const bchAccountBalance = await (() => {
-                    return new Promise(async (resolve, reject) => {
-                        coins.forEach(async each => {
-                            if (each.ticker === 'BCH') {
-                                const returned = flatten(
-                                    await accountLookup(
-                                        req.params.search,
-                                        each.addressLookUp,
-                                        each.addressEndpoint
-                                    )
-                                );
-                                if (returned.success === false) {
-                                    reject(0);
-                                } else {
-                                    const end = 'body.' + each.addressEndpoint;
-                                    const bchBalance = returned[end];
-                                    if (bchBalance === undefined) {
-                                        resolve(-1);
-                                    } else {
-                                        resolve(bchBalance);
-                                    }
-                                }
-                            }
-                        });
-                    });
-                })();
-                if (btcAccountBalance === -1 || bchAccountBalance === -1) {
-                    if (btcAccountBalance === -1) {
-                        const retJson = await addressCheck(req.params.search, 'BCH');
-                        res.json({
-                            input: req.params.search,
-                            success: true,
-                            coin: 'BCH',
-                            message:
-                                'Unable to find account balance for Bitcoin. Using Bitcoin Cash instead.',
-                            result: retJson
-                        });
-                    } else if (bchAccountBalance === -1) {
-                        const retJson = await addressCheck(req.params.search, 'BTC');
-                        res.json({
-                            input: req.params.search,
-                            success: true,
-                            coin: 'BTC',
-                            message:
-                                'Unable to find account balance for Bitcoin Cash. Using Bitcoin instead.',
-                            result: retJson
+                            message: 'Issue resolving ENS name.'
                         });
                     }
                 } else {
-                    if (btcAccountBalance > bchAccountBalance) {
-                        /* Searched for a BTC address */
-                        const retJson = await addressCheck(req.params.search, 'BTC');
-                        res.json({
-                            success: true,
-                            input: req.params.search,
-                            coin: 'BTC',
-                            result: retJson
-                        });
-                    } else if (bchAccountBalance > btcAccountBalance) {
-                        /* Searched for a BCH address */
-                        const retJson = await addressCheck(req.params.search, 'BCH');
-                        res.json({
-                            success: true,
-                            input: req.params.search,
-                            coin: 'BCH',
-                            result: retJson
-                        });
-                    } else if (
-                        (bchAccountBalance === 0 && btcAccountBalance === 0) ||
-                        btcAccountBalance === bchAccountBalance
-                    ) {
-                        /* No balance in BTC/BCH, defaulting to BTC */
-                        const retJson = await addressCheck(req.params.search, 'BTC');
-                        res.json({
-                            success: true,
-                            input: req.params.search,
-                            coin: 'BTC',
-                            result: retJson
-                        });
-                    }
+                    res.json({
+                        success: false,
+                        input: req.params.search,
+                        coin: 'ETH',
+                        type: 'ENS',
+                        validRoot: false,
+                        message: 'Invalid ENS name'
+                    });
                 }
-            }
-        } else if (/^[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}$/.test(req.params.search)) {
-            /* Searched for a LTC address */
-            const retJson = await addressCheck(req.params.search, 'LTC');
-            res.json({
-                success: true,
-                input: req.params.search,
-                coin: 'LTC',
-                result: retJson
-            });
-        } else if (
-            /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(
-                req.params.search
-            )
-        ) {
-            /* Searched for a domain */
-            const whitelistURL = db
-                .read()
-                .verified.find(
-                    entry =>
-                        (url.parse(req.params.search.toLowerCase()).hostname ||
-                            req.params.search.toLowerCase()) === url.parse(entry.url).hostname
+            } else if (
+                /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(
+                    req.params.search
+                )
+            ) {
+                /* Searched for a domain */
+                const whitelistURL = db
+                    .read()
+                    .verified.find(
+                        entry =>
+                            (url.parse(req.params.search.toLowerCase()).hostname ||
+                                req.params.search.toLowerCase()) === url.parse(entry.url).hostname
+                    );
+                const blacklistURL = db
+                    .read()
+                    .scams.find(
+                        entry =>
+                            (url.parse(req.params.search.toLowerCase()).hostname ||
+                                req.params.search.toLowerCase()) === entry.getHostname()
+                    );
+                if (whitelistURL) {
+                    res.json({
+                        input: req.params.search,
+                        success: true,
+                        result: {
+                            status: 'verified',
+                            type: 'domain',
+                            entries: [whitelistURL]
+                        }
+                    });
+                } else if (blacklistURL) {
+                    res.json({
+                        input: req.params.search,
+                        success: true,
+                        result: {
+                            status: 'blocked',
+                            type: 'domain',
+                            entries: [blacklistURL]
+                        }
+                    });
+                } else {
+                    res.json({
+                        input: req.params.search,
+                        success: true,
+                        result: {
+                            status: 'neutral',
+                            type: 'domain',
+                            entries: []
+                        }
+                    });
+                }
+            } else if (
+                /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$|^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/.test(
+                    req.params.search
+                )
+            ) {
+                /* Searched for an ip address */
+                const blacklistIP = Object.keys(db.read().index.ips).filter(
+                    ip => req.params.search.toLowerCase() === ip.toLowerCase()
                 );
-            const blacklistURL = db
-                .read()
-                .scams.find(
-                    entry =>
-                        (url.parse(req.params.search.toLowerCase()).hostname ||
-                            req.params.search.toLowerCase()) === entry.getHostname()
-                );
-            if (whitelistURL) {
-                res.json({
-                    input: req.params.search,
-                    success: true,
-                    result: {
-                        status: 'verified',
-                        type: 'domain',
-                        entries: [whitelistURL]
-                    }
-                });
-            } else if (blacklistURL) {
-                res.json({
-                    input: req.params.search,
-                    success: true,
-                    result: {
-                        status: 'blocked',
-                        type: 'domain',
-                        entries: [blacklistURL]
-                    }
-                });
+                if (blacklistIP.length > 0) {
+                    res.json({
+                        input: req.params.search,
+                        success: true,
+                        result: {
+                            status: 'neutral',
+                            type: 'ip',
+                            entries: blacklistIP
+                        }
+                    });
+                } else {
+                    res.json({
+                        input: req.params.search,
+                        success: true,
+                        result: {
+                            status: 'neutral',
+                            type: 'ip',
+                            entries: []
+                        }
+                    });
+                }
             } else {
                 res.json({
                     input: req.params.search,
-                    success: true,
-                    result: {
-                        status: 'neutral',
-                        type: 'domain',
-                        entries: []
-                    }
+                    success: false,
+                    message:
+                        'Incorrect search type (must be a BTC/BCH/ETC/ETC/LTC address / ip address / URL)'
                 });
             }
-        } else if (
-            /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$|^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/.test(
-                req.params.search
-            )
-        ) {
-            /* Searched for an ip address */
-            const blacklistIP = Object.keys(db.read().index.ips).filter(
-                ip => req.params.search.toLowerCase() === ip.toLowerCase()
-            );
-            if (blacklistIP.length > 0) {
-                res.json({
-                    input: req.params.search,
-                    success: true,
-                    result: {
-                        status: 'neutral',
-                        type: 'ip',
-                        entries: blacklistIP
-                    }
-                });
-            } else {
-                res.json({
-                    input: req.params.search,
-                    success: true,
-                    result: {
-                        status: 'neutral',
-                        type: 'ip',
-                        entries: []
-                    }
-                });
-            }
-        } else {
-            res.json({
-                input: req.params.search,
-                success: false,
-                message:
-                    'Incorrect search type (must be a BTC/BCH/ETC/ETC/LTC address / ip address / URL)'
-            });
         }
     }
 });

--- a/src/utils/testCoinType.ts
+++ b/src/utils/testCoinType.ts
@@ -1,0 +1,52 @@
+import coins from './endpoints';
+import * as db from './db';
+import { balanceLookup } from './balanceLookup';
+import * as Debug from 'debug';
+const debug = Debug('cointest');
+
+export const testCoinType = (address: string): Promise<any> => {
+    return new Promise(async (resolve, reject) => {
+        const cryptos = {};
+        db.read().prices.cryptos.forEach(coin => {
+            cryptos[coin.ticker] = coin.price;
+        });
+        //debug(JSON.stringify(cryptos, null,4));
+        const out = [];
+        if (true) {
+            coins.forEach(entry => {
+                const regex = new RegExp(entry.regex, 'g');
+                if (regex.test(address)) {
+                    out.push(entry);
+                }
+            });
+            if (out.length > 1) {
+                // There are 2+ entries that matched regex - ETH/ETC or BTC/BCH
+                await Promise.all(
+                    out.map(async entry => {
+                        const balance = await balanceLookup(address, entry.ticker);
+                        if (balance.balance === -1 || balance.balance === null) {
+                            balance.balance = 0;
+                        }
+                        entry.balance =
+                            balance.balance * Math.pow(10, Math.round(-1 * entry.decimal));
+                        entry.price = cryptos[entry.ticker];
+                        entry.value = entry.price * entry.balance;
+                    })
+                );
+                const maxValue = await Math.max.apply(Math, out.map(entry => entry.value)); // Finds the max value
+                if (maxValue === 0) {
+                    // Resolves with the coin object with the max value if there is a max. If they're the same and 0 value each, resolve with first in list.
+                    resolve(out[0]);
+                } else {
+                    resolve(await out.find(item => item.value === maxValue));
+                }
+            } else if (out.length === 1) {
+                resolve(out[0]);
+            } else {
+                reject();
+            }
+        } else {
+            reject();
+        }
+    });
+};

--- a/tests/testregex.ts
+++ b/tests/testregex.ts
@@ -1,0 +1,21 @@
+import * as reg from '../src/utils/testCoinType';
+
+const addresses = [
+    '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+    '0x9f5304DA62A5408416Ea58A17a92611019bD5ce3',
+    '1DEP8i3QJCsomS4BSMY2RpU1upv62aGvhD',
+    'LNT6qmyVbd7w3VCTXwvLrN6zTz5bmsWnkX',
+    '15h6MrWynwLTwhhYWNjw1RqCrhvKv3ZBsi'
+];
+const test = () => {
+    addresses.forEach(async address => {
+        //console.log(address);
+        try {
+            const data = await reg.testCoinType(address);
+            console.log(data);
+        } catch (e) {
+            console.log(e);
+        }
+    });
+};
+test();


### PR DESCRIPTION
Fixed the regex process for the `/v1/check/<address>` endpoint to be easier to read and easier to scale (add new cryptos). Added support for BCH cash addresses (q addresses).

All regex  is based off of the `/utils/endpoints` file now. 

To add a new crypto: 
1) Create a new coin in `endpoints.ts` and add valid information. 
2) Then add new crypto to ticker list here: https://github.com/CryptoScamDB/cryptoscamdb.org/wiki/Supported-Cryptocurrencies
